### PR TITLE
Use distribution_release instead of ansible_

### DIFF
--- a/aptly-snapshot-create.yml
+++ b/aptly-snapshot-create.yml
@@ -11,19 +11,20 @@
   tasks:
     - assert:
         that:
-          openstack_release is defined
+          - openstack_release is defined
+          - distribution_release is defined
         msg: You need to define what you are releasing!
-    - shell: "aptly {{ item }} list -raw | grep -e {{ ansible_distribution_release }} -e ALL {% if aptly_dont_snapshot_list is defined and aptly_dont_snapshot_list | length > 0 %}|grep -v -e {{ aptly_dont_snapshot_list | join(' -e ') }} {% endif %}"
+    - shell: "aptly {{ item }} list -raw | grep -e {{ distribution_release }} -e ALL {% if aptly_dont_snapshot_list is defined and aptly_dont_snapshot_list | length > 0 %}|grep -v -e {{ aptly_dont_snapshot_list | join(' -e ') }} {% endif %}"
       with_items:
         - repo
         - mirror
       register: aptly_repo_list
     - name: Froze the mirrors/repos by snapshot creation
-      shell: "aptly snapshot create slushie-{{ ansible_distribution_release }}-{{ openstack_release }}-{{ item.1 }} from {{ item.0.item }} {{ item.1 }}"
+      shell: "aptly snapshot create slushie-{{ distribution_release }}-{{ openstack_release }}-{{ item.1 }} from {{ item.0.item }} {{ item.1 }}"
       with_subelements:
         - "{{ aptly_repo_list.results }}"
         - "stdout_lines"
-    - shell: "aptly snapshot list -raw | grep slushie-{{ ansible_distribution_release }}-{{ openstack_release }}"
+    - shell: "aptly snapshot list -raw | grep slushie-{{ distribution_release }}-{{ openstack_release }}"
       register: aptly_snapshot_list
     - debug:
         msg: "Full list of snapshots for this distribution/openstack_release: {{ aptly_snapshot_list.stdout_lines }}"

--- a/aptly-snapshot-merge-and-publish.yml
+++ b/aptly-snapshot-merge-and-publish.yml
@@ -10,23 +10,24 @@
   tasks:
     - assert:
         that:
-          openstack_release is defined
+          - openstack_release is defined
+          - distribution_release is defined
         msg: You need to define what you are releasing!
-    - shell: "aptly snapshot list -raw | grep slushie-{{ ansible_distribution_release }}-{{ openstack_release }} {% if aptly_dont_merge_snapshot_list is defined and aptly_dont_merge_snapshot_list | length > 0 %}|grep -v -e {{ aptly_dont_merge_snapshot_list | join(' -e ') }} {% endif %}"
+    - shell: "aptly snapshot list -raw | grep slushie-{{ distribution_release }}-{{ openstack_release }} {% if aptly_dont_merge_snapshot_list is defined and aptly_dont_merge_snapshot_list | length > 0 %}|grep -v -e {{ aptly_dont_merge_snapshot_list | join(' -e ') }} {% endif %}"
       register: aptly_selected_snapshot_list
     - name: Merge the snapshots together
-      shell: "aptly snapshot merge slushie-{{ ansible_distribution_release }}-{{ openstack_release }} {{ aptly_selected_snapshot_list.stdout_lines | join(' ') }}"
+      shell: "aptly snapshot merge slushie-{{ distribution_release }}-{{ openstack_release }} {{ aptly_selected_snapshot_list.stdout_lines | join(' ') }}"
       when: (aptly_snapshot_merge | default(True)) | bool
       tags:
         - aptly_snapshot_merge
         - aptly_snapshot
     - name: Publish snapshot into public folder
-      shell: 'aptly publish snapshot -distribution="{{ ansible_distribution_release }}" slushie-{{ ansible_distribution_release }}-{{ openstack_release }} {{ openstack_release }}'
+      shell: 'aptly publish snapshot -distribution="{{ distribution_release }}" slushie-{{ distribution_release }}-{{ openstack_release }} {{ openstack_release }}'
       when: (aptly_snapshot_merge | default(True)) | bool
       tags:
         - aptly_publish
     - name: Publish snapshot into public folder (no merge)
-      shell: 'aptly publish snapshot -distribution="{{ ansible_distribution_release }}" {{ item }} {{ openstack_release }}/{{ item }}'
+      shell: 'aptly publish snapshot -distribution="{{ distribution_release }}" {{ item }} {{ openstack_release }}/{{ item }}'
       with_items: "{{ aptly_selected_snapshot_list.stdout_lines }}"
       when: not (aptly_snapshot_merge | default(True)) | bool
       tags:

--- a/aptly-sync-to-mirror.yml
+++ b/aptly-sync-to-mirror.yml
@@ -6,7 +6,7 @@
     - name: Synchronize cache
       synchronize:
         src: "{{ aptly_user_home }}/public/"
-        dest: "{{ artifacts_root_folder }}/apt/"
+        dest: "{{ artifacts_aptrepos_dest_folder }}"
       delegate_to: aptly_cache[0]
       register: synchronize
       until: synchronize|success

--- a/artifacting-vars.yml
+++ b/artifacting-vars.yml
@@ -1,6 +1,8 @@
 ---
-# Artifacts root folder
+# Artifacts folders
 artifacts_root_folder: "/openstack/artifcats"
+artifacts_aptrepos_dest_folder: "{{ artifacts_root_folder }}/apt/"
+fetch_artifact_destination_folder: "{{ artifacts_root_folder }}/downloads/"
 
 # External files to download for tempest and swift (cirros/pypy)
 fetch_version: "master"
@@ -8,7 +10,6 @@ fetch_information_sources:
   - "https://raw.githubusercontent.com/openstack/openstack-ansible-os_swift/{{ fetch_version }}/defaults/main.yml"
   - "https://raw.githubusercontent.com/openstack/openstack-ansible-os_tempest/{{ fetch_version }}/defaults/main.yml"
 fetch_local_temp_storage: "/tmp/download_other_artifacts"
-fetch_artifact_destination_folder: "{{ artifacts_root_folder }}/downloads/"
 
 # Aptly vars
 # Before going further, make sure you have keys.


### PR DESCRIPTION
Distribution release may not be the same as
ansible_distribution_release, if you want to build for xenial
under trusty or the opposite.