### PR TITLE
Ease up for first CI testing

### DIFF
--- a/aptly-vars.yml
+++ b/aptly-vars.yml
@@ -24,7 +24,7 @@ aptly_dependency_follow_suggests: True
 # This is a list of the repo/mirror snapshots (slushies) that will appear in the miko* snapshots
 aptly_miko_mapping:
   trusty:
-    - "slushie-{{ artifacts_version }}-ubuntu-trusty"
+#    - "slushie-{{ artifacts_version }}-ubuntu-trusty"
     - "slushie-{{ artifacts_version }}-uca-mitaka-updates-trusty"
     - "slushie-{{ artifacts_version }}-mariadb-10.0-trusty"
     - "slushie-{{ artifacts_version }}-percona-trusty"
@@ -35,7 +35,7 @@ aptly_miko_mapping:
     - "slushie-{{ artifacts_version }}-elastic-beats-ALL"
     - "slushie-{{ artifacts_version }}-elastic-es-1.7-ALL"
   xenial:
-    - "slushie-{{ artifacts_version }}-ubuntu-xenial"
+#    - "slushie-{{ artifacts_version }}-ubuntu-xenial"
     - "slushie-{{ artifacts_version }}-uca-newton-updates-xenial"
     - "slushie-{{ artifacts_version }}-mariadb-10.0-xenial"
     - "slushie-{{ artifacts_version }}-percona-xenial"
@@ -48,38 +48,38 @@ aptly_miko_mapping:
 #in the name of the mirror or of the repo, please
 #give either trusty/xenial (wherever appropriate) or ALL (for all distros)
 aptly_mirrors:
-  - name: ubuntu-trusty
-    archive_url: http://mirror.rackspace.com/ubuntu
-    distribution: trusty
-    component1:
-      - main
-      - restricted
-    create_flags:
-      - "-keyring='trustedkeys.gpg'"
-    update_flags:
-      - "-keyring='trustedkeys.gpg'"
-    state: "present"
-    gpg:
-      key: "C0B21F32 437D05B5"
-      server: "hkp://keyserver.ubuntu.com:80"
-      keyring: "trustedkeys.gpg"
-    do_update: "{{ aptly_mirror_do_updates }}"
-  - name: ubuntu-xenial
-    archive_url: http://mirror.rackspace.com/ubuntu
-    distribution: xenial
-    component1:
-      - main
-      - restricted
-    create_flags:
-      - "-keyring='trustedkeys.gpg'"
-    update_flags:
-      - "-keyring='trustedkeys.gpg'"
-    state: "present"
-    gpg:
-      key: "C0B21F32 437D05B5"
-      server: "hkp://keyserver.ubuntu.com:80"
-      keyring: "trustedkeys.gpg"
-    do_update: "{{ aptly_mirror_do_updates }}"
+#  - name: ubuntu-trusty
+#    archive_url: http://mirror.rackspace.com/ubuntu
+#    distribution: trusty
+#    component1:
+#      - main
+#      - restricted
+#    create_flags:
+#      - "-keyring='trustedkeys.gpg'"
+#    update_flags:
+#      - "-keyring='trustedkeys.gpg'"
+#    state: "present"
+#    gpg:
+#      key: "C0B21F32 437D05B5"
+#      server: "hkp://keyserver.ubuntu.com:80"
+#      keyring: "trustedkeys.gpg"
+#    do_update: "{{ aptly_mirror_do_updates }}"
+#  - name: ubuntu-xenial
+#    archive_url: http://mirror.rackspace.com/ubuntu
+#    distribution: xenial
+#    component1:
+#      - main
+#      - restricted
+#    create_flags:
+#      - "-keyring='trustedkeys.gpg'"
+#    update_flags:
+#      - "-keyring='trustedkeys.gpg'"
+#    state: "present"
+#    gpg:
+#      key: "C0B21F32 437D05B5"
+#      server: "hkp://keyserver.ubuntu.com:80"
+#      keyring: "trustedkeys.gpg"
+#    do_update: "{{ aptly_mirror_do_updates }}"
   - name: uca-mitaka-updates-trusty
     archive_url: http://ubuntu-cloud.archive.canonical.com/ubuntu
     distribution: trusty-updates/mitaka


### PR DESCRIPTION
To make sure we don't overload the repo server's disk capacity,
this change of vars reduce the scope of what's apt mirrored on
repo host.

This can be extended in the future.