### PR TITLE
Move to component instead of prefixes.

### DIFF
--- a/aptly-snapshot-merge-and-publish.yml
+++ b/aptly-snapshot-merge-and-publish.yml
@@ -24,8 +24,8 @@
       tags:
         - aptly_snapshot_merge
         - aptly_snapshot
-    - name: Publish snapshot into public folder
-      shell: 'aptly publish snapshot -distribution="{{ distribution_release }}" miko-{{ artifacts_version }}-{{ distribution_release }} {{ artifacts_version }}'
+    - name: Publish snapshot into public/integrated/ folder
+      shell: 'aptly publish snapshot -distribution="{{ distribution_release }}" -component="{{ artifacts_version }}" miko-{{ artifacts_version }}-{{ distribution_release }} integrated'
       register: aptly_snapshot_publish
       failed_when: aptly_snapshot_publish.rc != 0 and aptly_snapshot_publish.stderr.find('already used') == -1
       changed_when: aptly_snapshot_publish.stderr.find('already used') == -1
@@ -33,7 +33,7 @@
       tags:
         - aptly_publish
     - name: Publish snapshot into public folder (no merge)
-      shell: 'aptly publish snapshot -distribution="{{ distribution_release }}" {{ item }} {{ item }}/{{ artifacts_version }}'
+      shell: 'aptly publish snapshot -distribution="{{ distribution_release }}" -component="{{ artifacts_version }}" {{ item }} independant/{{ item }}'
       with_items: "{{ aptly_miko_mapping.get(distribution_release) }}"
       when: not (aptly_snapshot_merge | default(True)) | bool
       tags:


### PR DESCRIPTION
The apt pools are separated by their publish prefix. If we use
the tag as prefix, it will keep things well separated, including
the publishing folders, which would lead to more space used.

In this commit, we move to using components instead.
A release tag will therefore appear as a component under the
dist it would use.  We are using still keeping prefixes, but
only to keep the independant (no merge snapshots) and integrated
(merged snapshots) separated.