### PR TITLE
Fix hwraid.le-vert.net pkg conflict

### DIFF
--- a/aptly-vars.yml
+++ b/aptly-vars.yml
@@ -48,10 +48,10 @@ aptly_miko_mapping:
 aptly_n_mapping:
   trusty:
     - src: "slushie-{{ artifacts_version }}-hwraid-trusty"
-      dest: "hwraid"
+      dest: "hwraid-trusty"
   xenial:
     - src: "slushie-{{ artifacts_version }}-hwraid-xenial"
-      dest: "hwraid"
+      dest: "hwraid-xenial"
 
 #in the name of the mirror or of the repo, please
 #give either trusty/xenial (wherever appropriate) or ALL (for all distros)


### PR DESCRIPTION
hwraid.le-vert.net uses the same package name, version and
architecture for two different packages (in two separate distros).

This prevents one single pool to be used for both distros.

This commit splits the apt pools.