### PR TITLE
Correct git clone destination

### DIFF
--- a/openstackgit-update.yml
+++ b/openstackgit-update.yml
@@ -43,8 +43,8 @@
 
     - name: Fetch the openstackgit clones
       git:
-        repo: "{{ item.url }}"
-        dest: "{{ working_dir }}/openstackgit/"
+        repo: "{{ item['url'] }}"
+        dest: "{{ working_dir }}/openstackgit/{{ item['name'] }}"
         version: "master"
         update: true
         force: true


### PR DESCRIPTION
Currently the destination for all clones is the same directory,
so the resulting folder only contains the last clone. This patch
corrects the task to ensure that each clone is in its own dir.