### PR TITLE
Publish the apt key used for signing on mirror

### DIFF
--- a/aptly-all.yml
+++ b/aptly-all.yml
@@ -22,3 +22,6 @@
 - include: sync-with-mirror.yml
   vars:
     action: "push-aptly"
+- include: sync-with-mirror.yml
+  vars:
+    action: "push-gpg"

--- a/aptly-vars.yml
+++ b/aptly-vars.yml
@@ -8,8 +8,9 @@ aptly_clone_this_first:
     dest: "{{ ansible_roles_folder }}/infOpen.aptly"
     version: "rax"
 
-aptly_custom_gpg_key_file : "{{ artifacts_root_folder }}/aptly.private.key"
-aptly_custom_gpg_key_id: "{{ lookup('pipe','gpg ' + artifacts_root_folder + '/aptly.public.key | cut -f 2 -d \"/\" | cut -f 1 -d \" \" ') }}"
+aptly_custom_gpg_key_file: "{{ artifacts_root_folder }}/aptly.private.key"
+aptly_custom_gpg_pubkey_file: "{{ artifacts_root_folder }}/aptly.public.key"
+aptly_custom_gpg_key_id: "{{ lookup('pipe','gpg ' ~ aptly_custom_gpg_pubkey_file ~ '| cut -f 2 -d \"/\" | cut -f 1 -d \" \" ') }}"
 aptly_system_archive_gpg_keys_import: True
 aptly_user_home: "{{ artifacts_aptrepos_dest_folder }}"
 aptly_user: aptly

--- a/sync-with-mirror.yml
+++ b/sync-with-mirror.yml
@@ -1,4 +1,4 @@
-- name: Sync with mirror
+- name: Sync apt artifacts with mirror
   hosts: mirrors
   vars_files:
     - artifacting-vars.yml
@@ -38,7 +38,7 @@
           src: "{{ aptly_user_home }}"
           dest: "{{ artifacts_aptrepos_dest_folder | dirname }}"
 
-- name: Permissions handling
+- name: Ensure localhost has the permissions to manipulate aptly cache
   hosts: localhost
   connection: local
   vars_files:
@@ -58,7 +58,7 @@
           recurse: "yes"
           owner: "{{ aptly_user }}"
 
-- name: Permissions handling
+- name: Ensure mirror has the permissions to serve aptly public folders
   hosts: mirrors
   vars_files:
     - artifacting-vars.yml
@@ -76,3 +76,16 @@
           state: "directory"
           recurse: "yes"
           owner: "{{ webservice_owner }}"
+
+- name: Public serve the gpg used for signing
+  hosts: mirrors
+  vars_files:
+    - artifacting-vars.yml
+    - aptly-vars.yml
+  tasks:
+    - name: Sync apt public key with mirror
+      copy:
+        src: "{{ aptly_custom_gpg_pubkey_file }}"
+        dest: "{{ aptly_custom_gpg_pubkey_file }}"
+        owner: "{{ webservice_owner }}"
+      when: action=="push-gpg"


### PR DESCRIPTION
We need to publish the key used for signing apt packages if we
want to use apt mirror with gpgcheck (default on).

Signed-off-by: Jean-Philippe Evrard <jean-philippe.evrard@rackspace.co.uk>