### PR TITLE
Bring hwraid packages into merged snapshot

### DIFF
--- a/aptly-vars.yml
+++ b/aptly-vars.yml
@@ -34,6 +34,7 @@ aptly_miko_mapping:
     - "slushie-{{ artifacts_version }}-elastic-kibana-4.5-ALL"
     - "slushie-{{ artifacts_version }}-elastic-beats-ALL"
     - "slushie-{{ artifacts_version }}-elastic-es-1.7-ALL"
+    - "slushie-{{ artifacts_version }}-hwraid-trusty"
   xenial:
 #    - "slushie-{{ artifacts_version }}-ubuntu-xenial"
     - "slushie-{{ artifacts_version }}-uca-newton-updates-xenial"
@@ -44,6 +45,7 @@ aptly_miko_mapping:
     - "slushie-{{ artifacts_version }}-elastic-kibana-4.5-ALL"
     - "slushie-{{ artifacts_version }}-elastic-beats-ALL"
     - "slushie-{{ artifacts_version }}-elastic-es-1.7-ALL"
+    - "slushie-{{ artifacts_version }}-hwraid-xenial"
 # mapping for N (NOT MERGE) snapshots
 # This is a list of the repo/mirror snapshots (slushies) that will be published separately.
 aptly_n_mapping:


### PR DESCRIPTION
The merged snapshot didn't contain le-vert mirrored packages.
This should fix it.