### PR TITLE
Rollback components usage

### DIFF
--- a/aptly-snapshot-create.yml
+++ b/aptly-snapshot-create.yml
@@ -39,6 +39,7 @@
       when:
         - "{{ lookup('ENV','RECREATE_SNAPSHOTS') | default('NO') == 'YES' }}"
         - "item.find('{{ artifacts_version }}') != -1"
+        - "item.find('{{ distribution_release }}') != -1"
       failed_when: false
     - name: Delete old merged snapshots for this distro/artifacts version
       shell: "aptly snapshot drop {{ item }}"

--- a/aptly-snapshot-merge-and-publish.yml
+++ b/aptly-snapshot-merge-and-publish.yml
@@ -25,14 +25,14 @@
         - aptly_snapshot_merge
         - aptly_snapshot
     - name: Publish snapshot into public/integrated/ folder
-      shell: 'aptly publish snapshot -distribution="{{ distribution_release }}" -component="{{ artifacts_version }}" miko-{{ artifacts_version }}-{{ distribution_release }} integrated'
+      shell: 'aptly publish snapshot -distribution="{{ artifacts_version }}-{{ distribution_release }}" miko-{{ artifacts_version }}-{{ distribution_release }} integrated'
       register: aptly_snapshot_publish
       failed_when: aptly_snapshot_publish.rc != 0 and aptly_snapshot_publish.stderr.find('already used') == -1
       changed_when: aptly_snapshot_publish.stderr.find('already used') == -1
       tags:
         - aptly_publish
     - name: Publish snapshot into public folder (no merge)
-      shell: 'aptly publish snapshot -distribution="{{ distribution_release }}" -component="{{ artifacts_version }}" {{ item.src }} independant/{{ item.dest }}'
+      shell: 'aptly publish snapshot -distribution="{{ artifacts_version }}-{{ distribution_release }}" {{ item.src }} independant/{{ item.dest }}'
       with_items: "{{ aptly_n_mapping.get(distribution_release) }}"
       register: aptly_snapshot_nomerge_publish
       failed_when: aptly_snapshot_nomerge_publish.rc != 0 and aptly_snapshot_nomerge_publish.stderr.find('already used') == -1


### PR DESCRIPTION
We should use distro instead of components.

Components has the following issues:
- Adding a new component to a repo (like adding a new tag) automatically
  claims the component is already published if there is no change and
  not instructed to publish all the components (-components=,,)
- We cannot simply drop a component in place. We can switch it, but
  then it involves more wiring in code for automation.

Using distros with "/" would be the best solution, but aptly doesn't
allow that. In the meantime, a new RPC release will be in the apt
repository in the form artifact_version-system_distribution.

Signed-off-by: Jean-Philippe Evrard <jean-philippe.evrard@rackspace.co.uk>