### PR TITLE
Add aptly snapshot merge flags

### DIFF
--- a/aptly-snapshot-merge-and-publish.yml
+++ b/aptly-snapshot-merge-and-publish.yml
@@ -16,9 +16,8 @@
           - distribution_release is defined
         msg: You need to define what you are releasing!
     - name: Merge the snapshots together
-      shell: "aptly snapshot merge miko-{{ artifacts_version }}-{{ distribution_release }} {{ aptly_miko_mapping.get(distribution_release) | join(' ') }}"
+      shell: "aptly snapshot merge {{ aptly_snapshot_merge_flags }} miko-{{ artifacts_version }}-{{ distribution_release }} {{ aptly_miko_mapping.get(distribution_release) | join(' ') }}"
       register: aptly_snapshot_merge_create
-      when: (aptly_snapshot_merge | default(True)) | bool
       failed_when: aptly_snapshot_merge_create.rc != 0 and aptly_snapshot_merge_create.stderr.find('already exists') == -1
       changed_when: aptly_snapshot_merge_create.stderr.find('already exists') == -1
       tags:

--- a/aptly-vars.yml
+++ b/aptly-vars.yml
@@ -351,5 +351,5 @@ aptly_repos:
     create_flags:
       - '-comment="RabbitMQ Downloaded packages from RabbitMQ repo"'
     state: 'present'
-# NON APTLY ROLE
-aptly_snapshot_merge: True
+# Ensure aptly keeps all packages of all versions
+aptly_snapshot_merge_flags: "-no-remove=true"


### PR DESCRIPTION
If 2 versions of a the same package for the same architecture in
different repos exist, the order of the merge applies and the merged
snapshot will only get the package (with its possible many versions)
from one repo.

We need this to have versions 1.7 and 2.x for elasticsearch at the same
time in the merged repo.