### PR TITLE
Add git/python artifact staging playbook

### DIFF
--- a/stage-python-artifacts.yml
+++ b/stage-python-artifacts.yml
@@ -1,0 +1,244 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Stage the python artifacts
+  hosts: "{{ staging_host | default('localhost') }}"
+  user: root
+  vars:
+    upstream_artifact_base_url: "http://rpc-repo.rackspace.com"
+    # download_method options are ['get_url', 'aria']
+    download_method: "aria"
+    debug: yes
+  tasks:
+
+    - name: Set the staging path
+      set_fact:
+        staging_path: |-
+          {%- if groups['repo_all'] is defined -%}
+          /openstack/{{ hostvars[groups['repo_all'][0]]['inventory_hostname'] }}/repo
+          {%- else -%}
+          /openstack/stage
+          {%- endif -%}
+
+    - name: Fetch the upstream manifest file
+      uri:
+        url: "{{ upstream_artifact_base_url }}/os-releases/{{ rpc_release }}/MANIFEST.in"
+        return_content: yes
+        validate_certs: yes
+      register: manifest
+      tags: always
+
+    - name: Fetch the upstream venv list
+      uri:
+        url: "{{ upstream_artifact_base_url }}/venvs/{{ rpc_release }}/ubuntu/"
+        return_content: yes
+        validate_certs: yes
+      register: venv_index
+      tags: always
+
+    - name: Derive the lists of artifacts to download
+      set_fact:
+        python_wheel_list: |
+          {%- set content_list = manifest.content.split('\n') -%}
+          {%- set result_list = [] -%}
+          {%- for item in content_list -%}
+          {%-   if item.split('/')[0] == 'pools' -%}
+          {%-     set _ = result_list.append(item) -%}
+          {%-   endif -%}
+          {%- endfor -%}
+          {{- result_list -}}
+        git_folder_list: |
+          {%- set content_list = manifest.content.split('\n') -%}
+          {%- set result_list = [] -%}
+          {%- for item in content_list -%}
+          {%-   if item.split('/')[0] == 'openstackgit' -%}
+          {%-     set _ = result_list.append(item) -%}
+          {%-   endif -%}
+          {%- endfor -%}
+          {{- result_list -}}
+        python_venv_list: |
+          {%- set content_list = venv_index.content.split('\r\n') -%}
+          {%- set result_list = [] -%}
+          {%- for item in content_list -%}
+          {%-   if item | search("<a href.*>.*</a>") -%}
+          {%-     set item_clean = item | regex_replace(".*<a href.*>(.*)</a>.*", "\\1") -%}
+          {%-     if item_clean != "../" -%}
+          {%-       set _ = result_list.append(item_clean) -%}
+          {%-     endif -%}
+          {%-   endif -%}
+          {%- endfor -%}
+          {{- result_list -}}
+      tags: always
+
+    - name: Git staging folders setup
+      file:
+        path: "{{ item }}"
+        state: "directory"
+      with_items:
+        - "{{ staging_path }}/links"
+        - "{{ staging_path }}/openstackgit"
+        - "{{ staging_path }}/os-releases/{{ rpc_release }}"
+        - "{{ staging_path }}/venvs/{{ rpc_release }}/ubuntu"
+      tags: always
+
+    - name: Clone git repositories asynchronously
+      git:
+        repo: "{{ upstream_artifact_base_url }}/{{ item }}"
+        dest: "{{ staging_path }}/{{ item }}"
+        version: master
+        force: yes
+      with_items: "{{ git_folder_list }}"
+      register: _git_clone
+      async: 1800
+      poll: 0
+      tags: git
+
+    - name: Wait for git clones to complete
+      async_status:
+        jid: "{{ item['ansible_job_id'] }}"
+      register: _git_jobs
+      until: "{{ _git_jobs['finished'] | bool }}"
+      delay: 5
+      retries: 360
+      with_items: "{{ _git_clone['results'] }}"
+      when:
+        - item['ansible_job_id'] is defined
+      tags: git
+
+    - name: Python pools staging folders setup
+      file:
+        path: "{{ staging_path }}/{{ item | dirname }}"
+        state: "directory"
+      with_items: "{{ python_wheel_list }}"
+      when: download_method == "get_url"
+      tags:
+        - python
+        - get_url
+
+    - name: Download python wheels asynchronously
+      get_url:
+        url: "{{ upstream_artifact_base_url }}/{{ item }}"
+        dest: "{{ staging_path }}/{{ item }}"
+        validate_certs: yes
+      with_items: "{{ python_wheel_list }}"
+      when: download_method == "get_url"
+      register: _wheel_download
+      async: 1800
+      poll: 0
+      tags:
+        - python
+        - get_url
+
+    - name: Download python venvs asynchronously
+      get_url:
+        url: "{{ upstream_artifact_base_url }}/venvs/{{ rpc_release }}/ubuntu/{{ item }}"
+        dest: "{{ staging_path }}/venvs/{{ rpc_release }}/ubuntu/{{ item }}"
+        validate_certs: yes
+      with_items: "{{ python_venv_list }}"
+      when: download_method == "get_url"
+      register: _venv_download
+      async: 1800
+      poll: 0
+      tags:
+        - python
+        - get_url
+
+    - name: Wait for python wheel downloads to complete
+      async_status:
+        jid: "{{ item['ansible_job_id'] }}"
+      register: _wheel_download_jobs
+      until: "{{ _wheel_download_jobs['finished'] | bool }}"
+      delay: 5
+      retries: 360
+      with_items: "{{ _wheel_download['results'] }}"
+      when:
+        - download_method == "get_url"
+        - item['ansible_job_id'] is defined
+      tags:
+        - python
+        - get_url
+
+    - name: Wait for python venv downloads to complete
+      async_status:
+        jid: "{{ item['ansible_job_id'] }}"
+      register: _venv_download_jobs
+      until: "{{ _venv_download_jobs['finished'] | bool }}"
+      delay: 5
+      retries: 360
+      with_items: "{{ _venv_download['results'] }}"
+      when:
+        - download_method == "get_url"
+        - item['ansible_job_id'] is defined
+      tags:
+        - python
+        - get_url
+
+    - name: Install aria download manager
+      package:
+        name: "aria2"
+        state: present
+      when: download_method == "aria"
+      tags:
+        - python
+        - aria
+
+    - name: Write python artifact URL list
+      copy:
+        content: |
+          {% for item in python_wheel_list %}
+          {{ upstream_artifact_base_url }}/{{ item }}
+            dir={{ staging_path }}/{{ item | dirname }}
+          {% endfor %}
+          {% for item in python_venv_list %}
+          {{ upstream_artifact_base_url }}/venvs/{{ rpc_release }}/ubuntu/{{ item }}
+            dir={{ staging_path }}/venvs/{{ rpc_release }}/ubuntu
+          {% endfor %}
+        dest: "{{ staging_path }}/python_artifact_list.txt"
+      when: download_method == "aria"
+      tags:
+        - python
+        - aria
+
+    - name: Download python artifacts
+      command: "aria2c --input-file={{ staging_path }}/python_artifact_list.txt --allow-overwrite=true --conditional-get=true --quiet"
+      when: download_method == "aria"
+      tags:
+        - python
+        - aria
+
+    - name: Remove python artifact URL list
+      file:
+        path: "{{ staging_path }}/python_artifact_list.txt"
+        state: absent
+      when: "{{ not debug | bool }}"
+      tags:
+        - python
+        - aria
+
+    - name: Python releases symlinks
+      file:
+        src: "{{ staging_path }}/{{ item }}"
+        dest: "{{ staging_path }}/os-releases/{{ rpc_release }}/{{ item | regex_replace(item | dirname ~ '/', '') }}"
+        state: "link"
+      with_items: "{{ python_wheel_list }}"
+      tags: python
+
+    - name: Python links symlinks
+      file:
+        src: "{{ staging_path }}/{{ item }}"
+        dest: "{{ staging_path }}/links/{{ item | regex_replace(item | dirname ~ '/', '') }}"
+        state: "link"
+      with_items: "{{ python_wheel_list }}"
+      tags: python


### PR DESCRIPTION
This patch adds a utility playbook which will stage
all python artifacts for a given RPC release from
an upstream repository.

Connects https://github.com/rcbops/u-suk-dev/issues/766