### PR TITLE
Add apt staging playbook

### DIFF
--- a/stage-apt-artifacts-mirror.list.j2
+++ b/stage-apt-artifacts-mirror.list.j2
@@ -1,0 +1,31 @@
+############# {{ ansible_managed }} ##################
+#
+set base_path    /var/spool/apt-mirror
+set mirror_path  {{ staging_path }}/{{ artifact_repo_path }}
+set skel_path    $base_path/skel
+set var_path     $base_path/var
+set cleanscript $var_path/clean.sh
+set postmirror_script $var_path/postmirror.sh
+set run_postmirror 1
+set nthreads     20
+set _tilde 0
+#
+############# end config ##############
+
+#
+# Mirror section
+#
+
+{% for mirror in mirrors %}
+{%   for distribution in mirror['distributions'] %}
+deb {{ mirror['url'] }} {{ distribution['name'] }} {{ distribution['components'] | join(' ') }}
+{%   endfor %}
+{% endfor %}
+
+#
+# Cleaning section
+#
+
+{% for mirror in mirrors %}
+clean {{ mirror['url'] }}
+{% endfor %}

--- a/stage-apt-artifacts.yml
+++ b/stage-apt-artifacts.yml
@@ -1,0 +1,80 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Stage the apt artifacts
+  hosts: "{{ staging_host | default('localhost') }}"
+  user: root
+  vars:
+    upstream_artifact_base_url: "http://rpc-repo.rackspace.com/apt-mirror"
+    artifact_repo_path: "mirror-data"
+    keys:
+      - "rcbops-release-signing-key.asc"
+    mirrors:
+      - url: "{{ upstream_artifact_base_url }}/integrated"
+        distributions:
+          - name: "{{ rpc_release }}-trusty"
+            components:
+              - "main"
+          - name: "{{ rpc_release }}-xenial"
+            components:
+              - "main"
+      - url: "{{ upstream_artifact_base_url }}/independant/hwraid-trusty"
+        distributions:
+          - name: "{{ rpc_release }}-trusty"
+            components:
+              - "main"
+      - url: "{{ upstream_artifact_base_url }}/independant/hwraid-xenial"
+        distributions:
+          - name: "{{ rpc_release }}-xenial"
+            components:
+              - "main"
+  tasks:
+
+    - name: Set the staging path
+      set_fact:
+        staging_path: |-
+          {%- if groups['repo_all'] is defined -%}
+          /openstack/{{ hostvars[groups['repo_all'][0]]['inventory_hostname'] }}/repo
+          {%- else -%}
+          /openstack/stage
+          {%- endif -%}
+
+    - name: Git staging folders setup
+      file:
+        path: "{{ staging_path }}/{{ artifact_repo_path }}"
+        state: "directory"
+      tags: always
+
+    - name: Install apt-mirror
+      package:
+        name: "apt-mirror"
+        state: present
+
+    - name: Write the mirror configuration
+      template:
+        src: "stage-apt-artifacts-mirror.list.j2"
+        dest: "/etc/apt/mirror.list"
+
+    - name: Execute apt-mirror
+      command: "apt-mirror"
+
+    - name: Execute clean script
+      command: "/var/spool/apt-mirror/var/clean.sh"
+
+    - name: Implement the shorter link
+      file:
+        src: "{{ artifact_repo_path }}/{{ upstream_artifact_base_url | netloc_no_port }}/apt-mirror"
+        dest: "{{ staging_path }}/apt-mirror"
+        state: link


### PR DESCRIPTION
This patch adds an apt artifacts staging playbook
which uses apt-mirror to execute a complete mirror
of the RPC-O apt artifacts.

Connects https://github.com/rcbops/u-suk-dev/issues/1112