### PR TITLE
RO-3117 Ensure that file ownership is correct

### DIFF
--- a/apt/aptly-all.yml
+++ b/apt/aptly-all.yml
@@ -36,7 +36,7 @@
           - "--quiet"
           - "--stats"
           - "--log-file='/var/log/rpc-repo.log'"
-          - "--chown='{{ webservice_owner }}:www-data'"
+          - "--chown='{{ aptly_user }}:www-data'"
       register: synchronize
       until: synchronize | success
       retries: 5

--- a/apt/aptly-all.yml
+++ b/apt/aptly-all.yml
@@ -32,8 +32,6 @@
         dest: "{{ artifacts_aptrepos_dest_folder | dirname }}"
         mode: pull
         delete: yes
-        group: no
-        owner: no
         rsync_opts:
           - "--quiet"
           - "--stats"


### PR DESCRIPTION
In 6e6c3a2 the owner of the files when pulling was incorrectly
changed from the aptly_user to the webservice_owner. This results
in aptly not being able to operate on the database any more.

When setting owner/group to 'no' with the synchronise
module it passes the '--no-owner --no-group' parameters
to rsync which causes the '--chown' option to be ignored
and the ownership of the files to be set to the user
executing the rsync command (ie root). This results in
aptly not being able to operate on the database as the
files are owned by root instead of the aptly user.

When leaving the owner/group settings out of the module
settings no extra options are passed to rsync and '--chown'
works as expected.