### PR TITLE
RO-3117 Fix issues with downloading aptly data from rpc-repo

### DIFF
--- a/apt/aptly-all.yml
+++ b/apt/aptly-all.yml
@@ -32,6 +32,8 @@
         dest: "{{ artifacts_aptrepos_dest_folder | dirname }}"
         mode: pull
         delete: yes
+        group: no
+        owner: no
         rsync_opts:
           - "--quiet"
           - "--stats"

--- a/apt/aptly-install-and-mirror.yml
+++ b/apt/aptly-install-and-mirror.yml
@@ -19,6 +19,7 @@
 # check the armor and replace armor value below
 #    gpg --export-secret-keys --armor CB6E9D87 > /openstack/aptly.private.key
 #    gpg --export --armor CB6E9D87 > /openstack/aptly.public.key
+
 - name: Install aptly
   hosts: localhost
   connection: local
@@ -26,19 +27,36 @@
     - aptly-vars.yml
   vars:
     rabbitmq_package_url: "{{ _rabbitmq_package_url }}"
+
+  # The rsync from rpc-repo does not always set
+  # the right user:group, so we force the right
+  # user:group ownership over all the files in
+  # the aptly home directory here.
+  pre_tasks:
+    - name: Set appropriate owner and group
+      file:
+        path: "{{ aptly_user_home }}"
+        state: directory
+        owner: "{{ aptly_user }}"
+        group: "www-data"
+        recurse: yes
+
   #role will install aptly and update the mirrors
   roles:
     - infOpen.aptly
+
   # update repos
   post_tasks:
     - include_vars: "{{ ansible_roles_folder }}/rabbitmq_server/vars/debian.yml"
       failed_when: false
+
     - name: Verify if rabbitmq is already there, in case of re-run for the same artifact version
       command: su - aptly -c "aptly repo search rabbitmq-downloaded-packages-{{ rpc_release }}-ALL 'Name (rabbitmq-server), Version ({{ _rabbitmq_package_version }})'"
       register: rabbitmq_search
       failed_when: false
       changed_when: false
       when: aptly_mirror_do_updates | bool
+
     - name: Fetch Rabbitmq to feed frozen repo
       get_url:
         # from: https://raw.githubusercontent.com/openstack/openstack-ansible-rabbitmq_server/stable/newton/vars/debian.yml
@@ -52,12 +70,14 @@
       until: rabbitmq_download|success
       retries: 5
       delay: 5
+
     - name: Upload Package
       command: su - aptly -c "aptly repo add rabbitmq-downloaded-packages-{{ rpc_release }}-ALL /tmp/{{ _rabbitmq_package_url | basename }}"
       register: aptly_repo_add_output
       when:
         - aptly_mirror_do_updates | bool
         - rabbitmq_search.stdout.find(_rabbitmq_package_version) == -1
+
     - debug:
         msg: "{{ aptly_repo_add_output }}"
       when: aptly_mirror_do_updates | bool


### PR DESCRIPTION
When synchronising the aptly database from rpc-repo
rsync changes the owner:group to root when it is only
modifying the attributes of the file instead of the
contents - at least I think that's the condition.

After spending several hours trying to figure out
how to do it better in the rsync options, and failing,
this patch opts to use a simpler change which just
forces the owner:group after the sync is completed.

Some line spaces are added into the playbook to improve
readability.

Issue: [RO-3117](https://rpc-openstack.atlassian.net/browse/RO-3117)