### PR TITLE
RO-3117 Correct synchronize module usage

### DIFF
--- a/apt/aptly-all.yml
+++ b/apt/aptly-all.yml
@@ -32,13 +32,11 @@
         dest: "{{ artifacts_aptrepos_dest_folder | dirname }}"
         mode: pull
         delete: yes
-        group: no
-        owner: no
         rsync_opts:
           - "--quiet"
           - "--stats"
-          - "--log-file='/var/log/rpc-repo.log'"
-          - "--chown='{{ aptly_user }}:www-data'"
+          - "--log-file=/var/log/rpc-repo.log"
+          - "--chown={{ aptly_user }}:www-data"
       register: synchronize
       until: synchronize | success
       retries: 5
@@ -111,13 +109,11 @@
         dest: "{{ artifacts_aptrepos_dest_folder | dirname }}"
         mode: push
         delete: yes
-        group: no
-        owner: no
         rsync_opts:
           - "--quiet"
           - "--stats"
-          - "--log-file='/var/log/rpc-repo.log'"
-          - "--chown='{{ webservice_owner }}:www-data'"
+          - "--log-file=/var/log/rpc-repo.log"
+          - "--chown={{ webservice_owner }}:www-data"
       register: synchronize
       until: synchronize | success
       retries: 5
@@ -131,17 +127,3 @@
         owner: "{{ webservice_owner }}"
         group: "www-data"
       when: "{{ lookup('ENV','PUSH_TO_MIRROR') | bool }}"
-
-    # The rsync to rpc-repo does not always set
-    # the right user:group, so we force the right
-    # user:group ownership over all the files in
-    # the artifact directory here.
-    - name: Set appropriate owner and group
-      file:
-        path: "{{ artifacts_aptrepos_dest_folder }}"
-        state: directory
-        owner: "{{ webservice_owner }}"
-        group: "www-data"
-        recurse: yes
-      when: "{{ lookup('ENV','PUSH_TO_MIRROR') | bool }}"
-

--- a/apt/aptly-install-and-mirror.yml
+++ b/apt/aptly-install-and-mirror.yml
@@ -28,19 +28,6 @@
   vars:
     rabbitmq_package_url: "{{ _rabbitmq_package_url }}"
 
-  # The rsync from rpc-repo does not always set
-  # the right user:group, so we force the right
-  # user:group ownership over all the files in
-  # the aptly home directory here.
-  pre_tasks:
-    - name: Set appropriate owner and group
-      file:
-        path: "{{ aptly_user_home }}"
-        state: directory
-        owner: "{{ aptly_user }}"
-        group: "www-data"
-        recurse: yes
-
   #role will install aptly and update the mirrors
   roles:
     - infOpen.aptly


### PR DESCRIPTION
When setting owner/group to 'no' with the synchronise
module it passes the '--no-owner --no-group' parameters
to rsync which causes the '--chown' option to be ignored
and the ownership of the files to be set to the user
executing the rsync command (ie root). This results in
aptly not being able to operate on the database as the
files are owned by root instead of the aptly user.

When leaving the owner/group settings out of the module
settings no extra options are passed to rsync and '--chown'
works as expected.

Also, as mentioned in [1], quoting the rsync_opts arguments
breaks the functionality. Thus the quotes have been removed.

This has been extensively validated to be a working
implementation for Ansible 2.3 onwards in [2].

[1] https://github.com/ansible/ansible/issues/23575
[2] https://gist.github.com/odyssey4me/5817160155cc9ff7bd46aaef87fc2c07