### PR TITLE
RO-3146 Ensure inventory includes the key file

### DIFF
--- a/git/build-git-artifacts.sh
+++ b/git/build-git-artifacts.sh
@@ -108,6 +108,10 @@ if [[ "$(echo ${PUSH_TO_MIRROR} | tr [a-z] [A-Z])" == "YES" ]]; then
         # Ensure that the repo server public key is a known host
         grep "${REPO_HOST}" ~/.ssh/known_hosts || echo "${REPO_HOST} $(cat $REPO_HOST_PUBKEY)" >> ~/.ssh/known_hosts
 
+        # Ensure that the inventory contains all the right
+        # information, including the value for REPO_KEYFILE
+        envsubst < ${SCRIPT_PATH}/../inventory > /opt/inventory
+
         # Upload the artifacts to rpc-repo
         openstack-ansible -i /opt/inventory \
                           ${SCRIPT_PATH}/openstackgit-push-to-mirror.yml \


### PR DESCRIPTION
When the git artifact build wants to upload, the key
file path in the inventory is set to 'False' due to
the REPO_KEYFILE value not being present when the
inventory is prepared near the top of the script.

Given that the inventory is needed to run the initial
playbook, this patch just implements a rebuild of the
inventory if the right env vars are present just before
the upload is actioned.