### PR TITLE
RO-3156 Correct synchronise module usage

### DIFF
--- a/python/upload-python-artifacts.yml
+++ b/python/upload-python-artifacts.yml
@@ -65,7 +65,7 @@
         recursive: yes
         rsync_opts:
           - "--chown=nginx:www-data"
-          - "--exclude index.html"
+          - "--exclude=index.html"
       register: synchronize
       until: synchronize | success
       retries: 5


### PR DESCRIPTION
As per the notes in [1] each argument has to be a
seperate item in the list and each one is quoted.
To ensure that the exclusion key word and the value
being applied are taken as a single argument, we
make sure there are no spaces between them.

[1] https://github.com/ansible/ansible/issues/23575