### PR TITLE
RO-3284 Set AIO bootstrap options to ensure apt artifacts are used

### DIFF
--- a/python/build-python-artifacts.sh
+++ b/python/build-python-artifacts.sh
@@ -50,8 +50,8 @@ source ${SCRIPT_PATH}/../setup/artifact-setup.sh
 cd /opt/rpc-openstack
 
 # Set override vars for the artifact build
-echo "repo_build_wheel_selective: no" >> /etc/openstack_deploy/user_osa_variables_overrides.yml
-echo "repo_build_venv_selective: no" >> /etc/openstack_deploy/user_osa_variables_overrides.yml
+echo "repo_build_wheel_selective: no" >> ${OA_OVERRIDES}
+echo "repo_build_venv_selective: no" >> ${OA_OVERRIDES}
 
 # Set the galera client version number
 set_galera_client_version

--- a/setup/artifact-setup.sh
+++ b/setup/artifact-setup.sh
@@ -28,6 +28,12 @@ if [[ ! -e "/opt/rpc-openstack" ]]; then
   git clone https://github.com/rcbops/rpc-openstack.git /opt/rpc-openstack
 fi
 
+# The script to figure out the RPC_RELEASE does not work
+# unless python-yaml is installed. This is a temporary
+# workaround.
+# TODO(odyssey4me): Remove this once RO-3268 is resolved.
+apt-get update && apt-get install -y python-yaml
+
 # Install RPC-OpenStack
 pushd /opt/rpc-openstack
   OSA_RELEASE="${OSA_RELEASE:-stable/pike}" ./scripts/install.sh

--- a/setup/artifact-setup.sh
+++ b/setup/artifact-setup.sh
@@ -33,12 +33,20 @@ pushd /opt/rpc-openstack
   OSA_RELEASE="${OSA_RELEASE:-stable/pike}" ./scripts/install.sh
 popd
 
+# Source our functions
+source ${SCRIPT_PATH}/../functions.sh
+
+# Copy the extra-var override file over
 cp ${SCRIPT_PATH}/../user_*.yml /etc/openstack_deploy/
 
 # Set the python interpreter for consistency
-if ! grep -q '^ansible_python_interpreter' /etc/openstack_deploy/user_artifact_variables.yml; then
-  echo 'ansible_python_interpreter: "/usr/bin/python2"' | tee -a /etc/openstack_deploy/user_artifact_variables.yml
+if ! grep -q '^ansible_python_interpreter' ${OA_OVERRIDES}; then
+  echo 'ansible_python_interpreter: "/usr/bin/python2"' | tee -a ${OA_OVERRIDES}
 fi
 
-# Source our functions
-source ${SCRIPT_PATH}/../functions.sh
+# Set the AIO config bootstrap options
+if apt_artifacts_available; then
+    # Prevent the AIO bootstrap from re-implementing
+    # the updates, backports and UCA sources.
+    export BOOTSTRAP_OPTS='{ "bootstrap_host_apt_distribution_suffix_list": [], "uca_enable": "False" }'
+fi


### PR DESCRIPTION
Currently, when building the python artifacts, the deployment implements
the Ubuntu updates, backports and UCA repositories alongside the rpco apt
artifacts repository. This pollutes the python artifacts with binaries
which are not available in the apt artifact repository which may ultimately
cause service failures when trying to use the python artifacts.

This also affects the container artifact builds as they end up using the
wrong repositories, resulting in builds which differ on every execution.

This patch implements a change to the install script to set the OSA AIO
bootstrap options to prevent it from re-implementing the extra sources.

The functions loading is slightly adjusted so that we can make use of
the OA_OVERRIDES environment variable for the overrides implemented
instead of using yet another override file. The python build script
is then also set to use that variable instead of the file name for
improved consistency.