### PR TITLE
RO-3286 Bootstrap ansible with OSA for artifact builds

### DIFF
--- a/apt/build-apt-artifacts.sh
+++ b/apt/build-apt-artifacts.sh
@@ -47,9 +47,6 @@ export PUBLISH_SNAPSHOT=${PUBLISH_SNAPSHOT:-yes}
 export RPC_ARTIFACTS_FOLDER=${RPC_ARTIFACTS_FOLDER:-/var/www/artifacts}
 export RPC_ARTIFACTS_PUBLIC_FOLDER=${RPC_ARTIFACTS_PUBLIC_FOLDER:-/var/www/repo}
 
-# We do not want to rewrite the host apt sources when executing bootstrap-ansible
-export HOST_SOURCES_REWRITE="no"
-
 export SCRIPT_PATH="$(readlink -f $(dirname ${0}))"
 
 ## Main ----------------------------------------------------------------------
@@ -71,6 +68,11 @@ rm -rf /etc/ansible /etc/openstack_deploy /usr/local/bin/ansible* /usr/local/bin
 
 # Run basic setup
 source ${SCRIPT_PATH}/../setup/artifact-setup.sh
+
+# Bootstrap Ansible using OSA
+pushd /opt/openstack-ansible
+  bash -c "/opt/openstack-ansible/scripts/bootstrap-ansible.sh"
+popd
 
 cp ${SCRIPT_PATH}/lookup/* /etc/ansible/roles/plugins/lookup/
 

--- a/containers/build-process.sh
+++ b/containers/build-process.sh
@@ -48,6 +48,11 @@ rm -f /opt/list
 # Run basic setup
 source ${SCRIPT_PATH}/../setup/artifact-setup.sh
 
+# Bootstrap Ansible using OSA
+pushd /opt/openstack-ansible
+  bash -c "/opt/openstack-ansible/scripts/bootstrap-ansible.sh"
+popd
+
 # Set the galera client version number
 set_galera_client_version
 

--- a/python/build-python-artifacts.sh
+++ b/python/build-python-artifacts.sh
@@ -44,10 +44,10 @@ export SCRIPT_PATH="$(readlink -f $(dirname ${0}))"
 # Run basic setup
 source ${SCRIPT_PATH}/../setup/artifact-setup.sh
 
-# Bootstrap Ansible
-# This script is sourced to ensure that the common
-# functions and vars are available.
-cd /opt/rpc-openstack
+# Bootstrap Ansible using OSA
+pushd /opt/openstack-ansible
+  bash -c "/opt/openstack-ansible/scripts/bootstrap-ansible.sh"
+popd
 
 # Set override vars for the artifact build
 echo "repo_build_wheel_selective: no" >> ${OA_OVERRIDES}


### PR DESCRIPTION
Once RPC-O's configuration is implemented, ansible is
not available in a way that's useful to the artifact
builds. As such, we ensure that ansible is bootstrapped
appropriately before all artifact builds.