### PR TITLE
RO-3286 Clean up ansible bootstrapping

### DIFF
--- a/apt/build-apt-artifacts.sh
+++ b/apt/build-apt-artifacts.sh
@@ -38,16 +38,17 @@ export PUSH_TO_MIRROR=${PUSH_TO_MIRROR:-no}
 # know it and use this checkout appropriately.
 export BASE_DIR=${PWD}
 
-# We want the role downloads to be done via git
-# This ensures that there is no race condition with the artifacts-git job
-export ANSIBLE_ROLE_FETCH_MODE="git-clone"
-
 # These are allowed to be flexible for the purpose of testing by hand.
 export PUBLISH_SNAPSHOT=${PUBLISH_SNAPSHOT:-yes}
 export RPC_ARTIFACTS_FOLDER=${RPC_ARTIFACTS_FOLDER:-/var/www/artifacts}
 export RPC_ARTIFACTS_PUBLIC_FOLDER=${RPC_ARTIFACTS_PUBLIC_FOLDER:-/var/www/repo}
 
 export SCRIPT_PATH="$(readlink -f $(dirname ${0}))"
+
+# As apt artifacts are the first to be built, no
+# artifacts should be used for this build process.
+export ENABLE_ARTIFACTS_APT="no"
+export ENABLE_ARTIFACTS_PYT="no"
 
 ## Main ----------------------------------------------------------------------
 

--- a/apt/build-apt-artifacts.sh
+++ b/apt/build-apt-artifacts.sh
@@ -69,11 +69,6 @@ rm -rf /etc/ansible /etc/openstack_deploy /usr/local/bin/ansible* /usr/local/bin
 # Run basic setup
 source ${SCRIPT_PATH}/../setup/artifact-setup.sh
 
-# Bootstrap Ansible using OSA
-pushd /opt/openstack-ansible
-  bash -c "/opt/openstack-ansible/scripts/bootstrap-ansible.sh"
-popd
-
 cp ${SCRIPT_PATH}/lookup/* /etc/ansible/roles/plugins/lookup/
 
 # Figure out when it is safe to automatically replace artifacts

--- a/containers/build-process.sh
+++ b/containers/build-process.sh
@@ -48,11 +48,6 @@ rm -f /opt/list
 # Run basic setup
 source ${SCRIPT_PATH}/../setup/artifact-setup.sh
 
-# Bootstrap Ansible using OSA
-pushd /opt/openstack-ansible
-  bash -c "/opt/openstack-ansible/scripts/bootstrap-ansible.sh"
-popd
-
 # Set the galera client version number
 set_galera_client_version
 

--- a/containers/build-process.sh
+++ b/containers/build-process.sh
@@ -34,11 +34,12 @@ export PUSH_TO_MIRROR=${PUSH_TO_MIRROR:-no}
 # know it and use this checkout appropriately.
 export BASE_DIR=${PWD}
 
-# We want the role downloads to be done via git
-# This ensures that there is no race condition with the artifacts-git job
-export ANSIBLE_ROLE_FETCH_MODE="git-clone"
-
 export SCRIPT_PATH="$(readlink -f $(dirname ${0}))"
+
+# As container artifacts are built after apt & python artifacts,
+# they should be used if they are available.
+export ENABLE_ARTIFACTS_APT="yes"
+export ENABLE_ARTIFACTS_PYT="yes"
 
 ## Main ----------------------------------------------------------------------
 

--- a/functions.sh
+++ b/functions.sh
@@ -23,12 +23,14 @@ export REPO_KEYFILE=${REPO_KEYFILE:-~/.ssh/id_rsa}
 export BASE_DIR=${BASE_DIR:-"/opt/rpc-openstack"}
 export OA_DIR="/opt/openstack-ansible"
 export OA_OVERRIDES='/etc/openstack_deploy/user_osa_variables_overrides.yml'
-export RPCD_DIR="${BASE_DIR}"
 
 export HOST_SOURCES_REWRITE=${HOST_SOURCES_REWRITE:-"yes"}
 export HOST_UBUNTU_REPO=${HOST_UBUNTU_REPO:-"http://mirror.rackspace.com/ubuntu"}
 export HOST_RCBOPS_REPO=${HOST_RCBOPS_REPO:-"http://rpc-repo.rackspace.com"}
 export RPC_RELEASE="$(${BASE_DIR}/scripts/get-rpc_release.py)"
+
+export ENABLE_ARTIFACTS_APT=${ENABLE_ARTIFACTS_APT:-"no"}
+export ENABLE_ARTIFACTS_PYT=${ENABLE_ARTIFACTS_PYT:-"no"}
 
 # Read the OS information
 source /etc/os-release
@@ -77,7 +79,7 @@ function container_artifacts_available {
 
   CHECK_URL="${HOST_RCBOPS_REPO}/meta/1.0/index-system"
 
-  if curl --silent --fail ${CHECK_URL} | grep "^${ID};${DISTRIB_CODENAME};.*${RPC_RELEASE};" > /dev/null; then
+  if curl --silent --fail ${CHECK_URL} | grep -q "^${ID};${DISTRIB_CODENAME};.*${RPC_RELEASE};"; then
     return 0
   else
     return 1

--- a/git/build-git-artifacts.sh
+++ b/git/build-git-artifacts.sh
@@ -34,11 +34,12 @@ export PUSH_TO_MIRROR=${PUSH_TO_MIRROR:-no}
 # know it and use this checkout appropriately.
 export BASE_DIR=${PWD}
 
-# We want the role downloads to be done via git
-# This ensures that there is no race condition with the artifacts-git job
-export ANSIBLE_ROLE_FETCH_MODE="git-clone"
-
 export SCRIPT_PATH="$(readlink -f $(dirname ${0}))"
+
+# As git artifacts are built after apt artifacts,
+# they should be used if they are available.
+export ENABLE_ARTIFACTS_APT="yes"
+export ENABLE_ARTIFACTS_PYT="no"
 
 ## Main ----------------------------------------------------------------------
 # Run basic setup

--- a/python/build-python-artifacts.sh
+++ b/python/build-python-artifacts.sh
@@ -44,11 +44,6 @@ export SCRIPT_PATH="$(readlink -f $(dirname ${0}))"
 # Run basic setup
 source ${SCRIPT_PATH}/../setup/artifact-setup.sh
 
-# Bootstrap Ansible using OSA
-pushd /opt/openstack-ansible
-  bash -c "/opt/openstack-ansible/scripts/bootstrap-ansible.sh"
-popd
-
 # Set override vars for the artifact build
 echo "repo_build_wheel_selective: no" >> ${OA_OVERRIDES}
 echo "repo_build_venv_selective: no" >> ${OA_OVERRIDES}

--- a/python/build-python-artifacts.sh
+++ b/python/build-python-artifacts.sh
@@ -34,11 +34,12 @@ export PUSH_TO_MIRROR=${PUSH_TO_MIRROR:-no}
 # know it and use this checkout appropriately.
 export BASE_DIR=${PWD}
 
-# We want the role downloads to be done via git
-# This ensures that there is no race condition with the artifacts-git job
-export ANSIBLE_ROLE_FETCH_MODE="git-clone"
-
 export SCRIPT_PATH="$(readlink -f $(dirname ${0}))"
+
+# As python artifacts are built after apt artifacts,
+# they should be used if they are available.
+export ENABLE_ARTIFACTS_APT="yes"
+export ENABLE_ARTIFACTS_PYT="no"
 
 ## Main ----------------------------------------------------------------------
 # Run basic setup

--- a/setup/artifact-setup.sh
+++ b/setup/artifact-setup.sh
@@ -46,12 +46,16 @@ popd
 # Source our functions
 source ${SCRIPT_PATH}/../functions.sh
 
-# Bootstrap Ansible using OSA
-# We give it an a-r-r file which does not exist as the RPC-O install
-# process has already downloaded the roles.
-pushd /opt/openstack-ansible
-  bash -c "ANSIBLE_ROLE_FILE='/tmp/does-not-exist' scripts/bootstrap-ansible.sh"
-popd
+# Prepare the relevant artifacts
+openstack-ansible -i 'localhost,' \
+                  -e 'apt_target_group=localhost' \
+                  -e "apt_artifacts_enabled=${ENABLE_ARTIFACTS_APT}" \
+                  -e "container_artifact_enabled=no" \
+                  -e "py_artifact_enabled=${ENABLE_ARTIFACTS_PYT}" \
+                  "${BASE_DIR}/playbooks/site-artifacts.yml"
+
+# Install OpenStack-Ansible
+openstack-ansible "${BASE_DIR}/playbooks/openstack-ansible-install.yml"
 
 # Copy the extra-var override file over
 cp ${SCRIPT_PATH}/../user_*.yml /etc/openstack_deploy/

--- a/user_rcbops_artifacts_building.yml
+++ b/user_rcbops_artifacts_building.yml
@@ -94,3 +94,8 @@ lxc_cache_prep_pre_commands: |
     else
       rm -f /etc/resolv.conf
     fi
+
+# To ensure that playbooks targeted at localhost make
+# use of the host's python interpreter instead of the
+# ansible venv, we hard set the intepreter.
+ansible_python_interpreter: "/usr/bin/python2"


### PR DESCRIPTION
Instead of bootstrapping ansible in each build script
just do it in the artifact-setup script. Also clean
up some variable settings which do not need to be
done in bash as they're universal.