### PR TITLE
RO-3284 Correct rpc-openstack symlink condition

### DIFF
--- a/setup/artifact-setup.sh
+++ b/setup/artifact-setup.sh
@@ -32,7 +32,7 @@ export SCRIPT_PATH="$(readlink -f $(dirname ${0}))"
 # on its own.
 if [[ "${PWD}" != "/opt/rpc-openstack" ]] && [[ "${PWD}" =~ "rpc-openstack" ]]; then
   ln -sfn ${PWD} /opt/rpc-openstack
-else
+elif [[ "${PWD}" != "/opt/rpc-openstack" ]]; then
   git clone https://github.com/rcbops/rpc-openstack.git /opt/rpc-openstack
   rm -rf /opt/rpc-openstack/scripts/artifacts-building
   ln -sfn ${PWD} /opt/rpc-openstack/scripts/artifacts-building


### PR DESCRIPTION
If the current working directory the script is run
from is /opt/rpc-openstack, then we should not try
to symlink or clone to that location.