### PR TITLE
RO-3316 Correct image compression method

### DIFF
--- a/containers/artifact-build-chroot.yml
+++ b/containers/artifact-build-chroot.yml
@@ -21,10 +21,12 @@
   vars_files:
     - container-vars.yml
   tasks:
+
     - name: Remove base container
       lxc_container:
         name: "LXC_NAME"
         state: absent
+
     - name: Create base container
       lxc_container:
         name: "LXC_NAME"
@@ -38,12 +40,14 @@
           --force-cache
           --server images.linuxcontainers.org
           --keyserver hkp://p80.pool.sks-keyservers.net:80
+
     - name: Prepare group of master lxc hosts
       add_host:
         name: "/var/lib/lxc/LXC_NAME/rootfs/"
         groups: "lxc_container_artifact_chroots,{{ image_name }}_all"
         container_name: "LXC_NAME"
         physical_host: "localhost"
+
     # The nova role uses the with_random_choice lookup. The lookup is
     # processed before the task, so the lookup must be able to work
     # even if the task is not processed. For the lookup to work, the
@@ -59,6 +63,8 @@
   tags:
     - always
 
+
+
 - name: Install python
   hosts: lxc_container_artifact_chroots
   gather_facts: False
@@ -66,6 +72,7 @@
   vars_files:
     - container-vars.yml
   tasks:
+
     - name: Configure chroot
       raw: |
         if [ -e /etc/resolv.conf ]; then
@@ -76,6 +83,7 @@
         test -e /usr/bin/python || (apt-get -y update && apt-get install -y python-minimal)
       tags:
         - always
+
     # TODO(odyssey4me):
     # Remove this once all roles have developer mode package
     # install tasks which include git.
@@ -86,6 +94,8 @@
       when: "(developer_mode | default('no')) | bool"
   tags:
     - always
+
+
 
 - name: Run role
   hosts: lxc_container_artifact_chroots
@@ -100,13 +110,16 @@
   vars_files:
     - container-vars.yml
   pre_tasks:
+
     - name: Set facts to pass some variables that wouldn't work #like '{{ image_name }}_developer_mode'
       set_fact: '{{ image_name }}_{{ item.key }}="{{ item.value }}"'
       with_dict: "{{ role_vars }}"
       tags:
         - always
+
   roles:
     - role: "{{ role_name }}"
+
   post_tasks:
     - name: chroot cleanup
       shell: |
@@ -122,6 +135,8 @@
       tags:
         - always
 
+
+
 - name: Create artifact container
   hosts: localhost
   connection: local
@@ -131,13 +146,16 @@
   vars:
     image_name: "{{ role_name | replace('os_', '') }}"
   tasks:
+
     - name: Set artifact facts
       set_fact:
         image_path: "{{ lxc_image_folder }}/{{ lxc_index_path }}/{{ image_name }}-{{ rpc_release }}/{{ build_id }}/"
+
     - name: Ensure image doesn't exist yet.
       file:
         path: "{{ image_path }}"
         state: absent
+
     - name: Container image directories
       file:
         path: "{{ item }}"
@@ -146,36 +164,37 @@
       with_items:
         - "{{ image_path }}"
         - "{{ lxc_image_folder }}/"
+
     - name: Create lxc image
       shell: |
-        tar -Opc -C /var/lib/lxc/LXC_NAME/rootfs . | \
-          {{ xz_bin[ansible_distribution | lower] }} -{{ compression_ratio }} \
-          -c - > rootfs.tar.xz
+        tar -Jcf rootfs.tar.xz /var/lib/lxc/LXC_NAME/rootfs
       args:
         chdir: "{{ image_path }}"
         creates: "{{ image_path }}/rootfs.tar.xz"
         executable: /bin/bash
+
     - name: Create lxc image meta
       shell: |
-        tar -Opc -C {{ lxc_container_cache_path }}/{{ lxc_index_path }}/default/ {build_id,config,config-user,create-message,excludes-user,expiry,templates} | \
-          {{ xz_bin[ansible_distribution | lower] }} -{{ compression_ratio }} \
-          -c - > meta.tar.xz
+        tar -Jcf meta.tar.xz {{ lxc_container_cache_path }}/{{ lxc_index_path }}/default/{build_id,config,config-user,create-message,excludes-user,expiry,templates}
       args:
         chdir: "{{ image_path }}"
         creates: "{{ image_path }}/meta.tar.xz"
         executable: /bin/bash
+
     - name: Create release index entries
       lineinfile:
         dest: "{{ built_container_artifact_metadata_file }}"
         line: "{{ lxc_index_entry }};{{ image_name }}-{{ rpc_release }};{{ build_id }};/{{ rpc_mirror_container_relative_image_location }}/"
         create: yes
         state: present
+
     - name: create sha256sums
       shell: |
         echo "$(sha256sum {{ image_path }}/rootfs.tar.xz | awk '{print $1}') rootfs.tar.xz" | tee SHA256SUMS
         echo "$(sha256sum {{ image_path }}/meta.tar.xz | awk '{print $1}') meta.tar.xz" | tee -a SHA256SUMS
       args:
         chdir: "{{ image_path }}"
+
   post_tasks:
     - name: Remove base container
       lxc_container:
@@ -183,6 +202,8 @@
         state: absent
   tags:
     - always
+
+
 
 - name: container artifacts metadata prep
   hosts: localhost
@@ -192,20 +213,24 @@
   vars:
     image_name: "{{ role_name | replace('os_', '') }}"
   tasks:
+
     - name: Check if the list exist to avoid re-hitting the server
       stat:
         path: /opt/list
       register: metadata_file_locally_exists
+
     - name: get the container artifacts list
       get_url:
         url: "{{ rpc_mirror_container_images_list }}"
         dest: "/opt/list"
       when: not metadata_file_locally_exists.stat.exists
+
     - name: patch the current list with the new artifact
       lineinfile:
         dest: "/opt/list"
         regexp: "^{{ lxc_index_entry }};{{ image_name }}-{{ rpc_release }}"
         line: "{{ lookup('file', built_container_artifact_metadata_file ) }}"
+
     - name: Remove the metadata file
       file:
         path: "{{ built_container_artifact_metadata_file }}"

--- a/containers/container-vars.yml
+++ b/containers/container-vars.yml
@@ -20,10 +20,6 @@ lxc_image_folder: "/var/cache/artifacts"
 built_container_artifact_metadata_file: "{{ lxc_image_folder }}/{{ image_name }}-{{ rpc_release }}-entry"
 webserver_container_artifacts_uri: "lxc-images"
 lxc_container_cache_path: "/var/cache/lxc/download"
-compression_ratio: 7
-xz_bin:
-  centos: xz
-  ubuntu: pxz
 architecture_mapping:
   x86_64: amd64
   ppc64le: ppc64el


### PR DESCRIPTION
When consuming the images prepared with machinectl,
the current method causes machinectl to hang during
the decompression of the image and spikes the CPU
usage to 100%. This affects the RPC-O container
images, but does not happen with upstream images.

In reviewing the difference with how the compression
is done upstream [1], it uses the default compression
rather than our elevated compression and uses a far
simpler set of command-line options.

This patch changes our preparation of the compressed
container images to use the same command line options
for maximum compatibility.

Extra line breaks are added into the playbook in order
to improve readability.

[1] https://github.com/lxc/lxc-ci/blob/9706d80acb6dc2bd3ea519aed82b1b1940953120/bin/build-image#L166