### PR TITLE
RE-1267 Source functions before using them

### DIFF
--- a/containers/build-process.sh
+++ b/containers/build-process.sh
@@ -34,7 +34,11 @@ export PUSH_TO_MIRROR=${PUSH_TO_MIRROR:-no}
 # know it and use this checkout appropriately.
 export BASE_DIR=${PWD}
 
+# Figure out where this script is being run from
 export SCRIPT_PATH="$(readlink -f $(dirname ${0}))"
+
+# Source our functions
+source ${SCRIPT_PATH}/../functions.sh
 
 # As container artifacts are built after apt & python artifacts,
 # they should be used if they are available.

--- a/git/build-git-artifacts.sh
+++ b/git/build-git-artifacts.sh
@@ -34,7 +34,11 @@ export PUSH_TO_MIRROR=${PUSH_TO_MIRROR:-no}
 # know it and use this checkout appropriately.
 export BASE_DIR=${PWD}
 
+# Figure out where this script is being run from
 export SCRIPT_PATH="$(readlink -f $(dirname ${0}))"
+
+# Source our functions
+source ${SCRIPT_PATH}/../functions.sh
 
 # As git artifacts are built after apt artifacts,
 # they should be used if they are available.

--- a/python/build-python-artifacts.sh
+++ b/python/build-python-artifacts.sh
@@ -34,7 +34,11 @@ export PUSH_TO_MIRROR=${PUSH_TO_MIRROR:-no}
 # know it and use this checkout appropriately.
 export BASE_DIR=${PWD}
 
+# Figure out where this script is being run from
 export SCRIPT_PATH="$(readlink -f $(dirname ${0}))"
+
+# Source our functions
+source ${SCRIPT_PATH}/../functions.sh
 
 # As python artifacts are built after apt artifacts,
 # they should be used if they are available.


### PR DESCRIPTION
Currently the functions to verify whether artifacts are
available or not are used prior to them being available,
causing unexpected results. This patch makes sure that
they are sourced before using them.