### PR TITLE
RE-1267 Correct existing artifact availability checks

### DIFF
--- a/containers/build-process.sh
+++ b/containers/build-process.sh
@@ -37,17 +37,10 @@ export BASE_DIR=${PWD}
 # Figure out where this script is being run from
 export SCRIPT_PATH="$(readlink -f $(dirname ${0}))"
 
-# Source our functions
-source ${SCRIPT_PATH}/../functions.sh
-
 # As container artifacts are built after apt & python artifacts,
 # they should be used if they are available.
-if apt_artifacts_available; then
-  export ENABLE_ARTIFACTS_APT="yes"
-fi
-if python_artifacts_available; then
-  export ENABLE_ARTIFACTS_PYT="yes"
-fi
+export ENABLE_ARTIFACTS_APT="yes"
+export ENABLE_ARTIFACTS_PYT="yes"
 
 ## Main ----------------------------------------------------------------------
 

--- a/git/build-git-artifacts.sh
+++ b/git/build-git-artifacts.sh
@@ -37,14 +37,10 @@ export BASE_DIR=${PWD}
 # Figure out where this script is being run from
 export SCRIPT_PATH="$(readlink -f $(dirname ${0}))"
 
-# Source our functions
-source ${SCRIPT_PATH}/../functions.sh
-
 # As git artifacts are built after apt artifacts,
 # they should be used if they are available.
-if apt_artifacts_available; then
-  export ENABLE_ARTIFACTS_APT="yes"
-fi
+export ENABLE_ARTIFACTS_APT="yes"
+export ENABLE_ARTIFACTS_PYT="no"
 
 ## Main ----------------------------------------------------------------------
 # Run basic setup

--- a/python/build-python-artifacts.sh
+++ b/python/build-python-artifacts.sh
@@ -37,14 +37,10 @@ export BASE_DIR=${PWD}
 # Figure out where this script is being run from
 export SCRIPT_PATH="$(readlink -f $(dirname ${0}))"
 
-# Source our functions
-source ${SCRIPT_PATH}/../functions.sh
-
 # As python artifacts are built after apt artifacts,
 # they should be used if they are available.
-if apt_artifacts_available; then
-  export ENABLE_ARTIFACTS_APT="yes"
-fi
+export ENABLE_ARTIFACTS_APT="yes"
+export ENABLE_ARTIFACTS_PYT="no"
 
 ## Main ----------------------------------------------------------------------
 # Run basic setup

--- a/setup/artifact-setup.sh
+++ b/setup/artifact-setup.sh
@@ -46,6 +46,14 @@ popd
 # Source our functions
 source ${SCRIPT_PATH}/../functions.sh
 
+# If are not available then the use of them should be disabled.
+if ! apt_artifacts_available; then
+  export ENABLE_ARTIFACTS_APT="no"
+fi
+if ! python_artifacts_available; then
+  export ENABLE_ARTIFACTS_PYT="no"
+fi
+
 # Prepare the relevant artifacts
 openstack-ansible -i 'localhost,' \
                   -e 'apt_target_group=localhost' \
@@ -60,7 +68,7 @@ openstack-ansible "${BASE_DIR}/playbooks/openstack-ansible-install.yml"
 # Copy the extra-var override file over
 cp ${SCRIPT_PATH}/../user_*.yml /etc/openstack_deploy/
 
-if apt_artifacts_available; then
+if [[ "${ENABLE_ARTIFACTS_APT}" == "yes" ]]; then
   # Prevent the AIO bootstrap from re-implementing
   # the updates, backports and UCA sources.
   export BOOTSTRAP_OPTS='{ "bootstrap_host_apt_distribution_suffix_list": [], "uca_enable": "False" }'


### PR DESCRIPTION
Currently the checks run before a python package is installed
to run the script which figures out the rpc_release value. As
such we need to do the checks in the install script after the
installation of the python package, but before the preparation
of the artifact configuration.

This implementation simply disabled their use if they are not
available. As this is the default, it will only take effect if
the artifacts are not available and the artifact build script
intended to use them.