### PR TITLE
RE-1280 Fix regex match for non-merged snapshot

### DIFF
--- a/apt/aptly-snapshot-create.yml
+++ b/apt/aptly-snapshot-create.yml
@@ -65,7 +65,7 @@
   with_items: "{{ aptly_existing_snapshots_list.stdout_lines }}"
   when:
     - "lookup('ENV','RECREATE_SNAPSHOTS') | bool"
-    - "item | match('^slushie-{{ rpc_release }}-[a-zA-z]+-.*-({{ distribution_release }}|ALL)$')"
+    - "item | match('^slushie-{{ rpc_release }}-[a-zA-z]+-.*({{ distribution_release }}|ALL)$')"
   failed_when: false
 
 - name: Froze the mirrors/repos by snapshot creation


### PR DESCRIPTION
Currently 'slushie-r16.0.0-erlang-xenial' does not get
matched for the snapshot delete process when replacing
an existing snapshot. This is due to it missing the
extra '-' in the name required by the current regex.