### PR TITLE
RO-3777 Prevent unintended LXC index data loss

### DIFF
--- a/containers/artifact-build-chroot.yml
+++ b/containers/artifact-build-chroot.yml
@@ -228,7 +228,7 @@
     - name: patch the current list with the new artifact
       lineinfile:
         dest: "/opt/list"
-        regexp: "^{{ lxc_index_entry }};{{ image_name }}-{{ rpc_release }}"
+        regexp: "^{{ lxc_index_entry }};{{ image_name }}-{{ rpc_release }};"
         line: "{{ lookup('file', built_container_artifact_metadata_file ) }}"
 
     - name: Remove the metadata file


### PR DESCRIPTION
Currently due to a poor regex match, the index items for
content such as [1] are being replaced when trying to add
[2]. This patch adds the appropriate delimiter to prevent
this from happening.

[1] ubuntu;xenial;amd64;rsyslog_server-r16.0.0-beta.1;...
[2] ubuntu;xenial;amd64;rsyslog_server-r16.0.0;...