### PR TITLE
RO-3856 Set the container build script to be a no-op

### DIFF
--- a/containers/build-process.sh
+++ b/containers/build-process.sh
@@ -13,6 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+##
+## This process is no longer required. See the following JIRA card for
+## more details: https://rpc-openstack.atlassian.net/browse/RO-3856
+##
+## Instead of removing this code, the script is just set to exit
+## immediately. This allows the CI jobs to continue functioning
+## normally until the container artifact building is appropriately
+## removed from all relevant RPC-O branches and repositories.
+##
+exit 0
+
 ## Shell Opts ----------------------------------------------------------------
 
 set -e -u -x


### PR DESCRIPTION
Trying to use pre-built container images with the current
deployment system has turned out to be a bad idea. It has
raised a constant game of whack-a-mole with missing log
file folders [1][2][3][4][5] and other yet-to-find obscure
errors due to the way that OSA was designed to be deployed
(everything done at runtime) versus the desired RPC-O
implementation (pre-build as much as possible).

While we go back to the drawing board and rather implement
the artifact-based deployment method upstream, it'd be
better for us to cut out this technical debt so that we
have better deployment and upgrade success while we revisit
this approach upstream for a more sustainable solution.

This patch makes the container artifact build process be
a no-op so that the existing jobs can run as-is. This is
a temporary measure to facilitate the transition being
handled in all applicable repositories.

[1] RO-3654
[2] RO-3856
[3] RLM-1094
[4] RLM-324
[5] RO-3522